### PR TITLE
fix SV-Zanshin/INA#12

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -69,7 +69,7 @@ void INA_Class::writeInatoEEPROM(const uint8_t deviceNumber) {                //
 /*******************************************************************************************************************
 ** Method setI2CSpeed chagnes the I2C bus speed                                                                   **
 *******************************************************************************************************************/
-void INA_Class::setI2CSpeed(const uint16_t i2cSpeed ) {                       //                                  //
+void INA_Class::setI2CSpeed(const uint32_t i2cSpeed ) {                       //                                  //
   Wire.setClock(i2cSpeed);                                                    // Set the I2C Speed to value       //
 } // of method setI2CSpeed                                                    //                                  //
 /*******************************************************************************************************************

--- a/src/INA.h
+++ b/src/INA.h
@@ -85,10 +85,10 @@
   *****************************************************************************************************************/
   #ifndef I2C_MODES                                                           // I2C related constants            //
     #define I2C_MODES                                                         // Guard code to prevent multiple   //
-    const uint16_t I2C_STANDARD_MODE            =  100000;                    // Default normal I2C 100KHz speed  //
-    const uint16_t I2C_FAST_MODE                =  400000;                    // Fast mode                        //
-    const uint16_t I2C_FAST_MODE_PLUS           = 1000000;                    // Really fast mode                 //
-    const uint16_t I2C_HIGH_SPEED_MODE          = 3400000;                    // Turbo mode                       //
+    const uint32_t I2C_STANDARD_MODE            =  100000;                    // Default normal I2C 100KHz speed  //
+    const uint32_t I2C_FAST_MODE                =  400000;                    // Fast mode                        //
+    const uint32_t I2C_FAST_MODE_PLUS           = 1000000;                    // Really fast mode                 //
+    const uint32_t I2C_HIGH_SPEED_MODE          = 3400000;                    // Turbo mode                       //
   #endif                                                                      //----------------------------------//
   const uint8_t  INA_CONFIGURATION_REGISTER     =       0;                    //==================================//
   const uint8_t  INA_BUS_VOLTAGE_REGISTER       =       2;                    // Values common to all INAs        //
@@ -155,7 +155,7 @@
       uint8_t  begin             (const uint8_t  maxBusAmps,                  // Class initializer                //
                                   const uint32_t microOhmR,                   //                                  //
                                   const uint8_t  deviceNumber = UINT8_MAX );  //                                  //
-      void     setI2CSpeed       (const uint16_t i2cSpeed =I2C_STANDARD_MODE);// Adjust the I2C bus speed         //
+      void     setI2CSpeed       (const uint32_t i2cSpeed =I2C_STANDARD_MODE);// Adjust the I2C bus speed         //
       void     setMode           (const uint8_t  mode,                        // Set the monitoring mode          //
                                   const uint8_t  devNumber=UINT8_MAX);        //                                  //
       void     setAveraging      (const uint16_t averages,                    // Set the number of averages taken //


### PR DESCRIPTION
# Description
the `I2C_MODES` are [defined][modes] as `uint16_t`. The type too small to hold their actual values,
which triggers several overflow warnings like the following:

```
INA/src/INA.h:88:52: warning: large integer implicitly truncated to unsigned type [-Woverflow]
const uint16_t I2C_STANDARD_MODE            =  100000;                    // Default normal I2C 100KHz speed  //
^
```

The type be `uint32_t` as in the `Wire.setClock` [definition][core].
The argument to `INA_Class.setI2CSpeed` argument should also be `uint32_t`.

[modes]: https://github.com/SV-Zanshin/INA/blob/master/src/INA.h#L88-L91
[core]: https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/Wire/src/Wire.h#L56

Fixes #12 

# Type of change

- Bug fix (non-breaking change which fixes issue #12)

# How Has This Been Tested?

- compiled the DisplayReadings for different ATmegas using platformio
  - ATmega168 (board `pro8MHzatmega168`)
  - ATmega328 (board `pro8MHzatmega328`)
  - ATmega32u4 (board `micro`)
  - ATmega2560 (board `megaatmega2560`)

**Test Configuration**:
- Arduino version: Platform Atmel AVR, from PlatformIO
  - atmelavr 1.9.0
  - toolchain-atmelavr 1.40902.0
  - framework-arduinoavr 1.10621.1
- Arduino Hardware: None so far, just complied the code
- SDK: PlatformIO, version 3.5.4

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [x] My changes generate no new warnings
- [ ] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes