### PR TITLE
Reduce EEPROM footprint

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -54,8 +54,9 @@ void INA_Class::writeWord(const uint8_t addr, const uint16_t data,            //
 *******************************************************************************************************************/
 void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {               //                                  //
   if (deviceNumber!=_currentINA) {                                            // Only read EEPROM if necessary    //
-    EEPROM.get(deviceNumber*sizeof(ina),ina);                                 // Read EEPROM values               //
+    EEPROM.get(deviceNumber*sizeof(inaEE),inaEE);                             // Read EEPROM values               //
     _currentINA = deviceNumber;                                               // Store new current value          //
+    ina = inaEE;                                                              // see inaDet constructor           //
   } // of if-then we have a new device                                        //                                  //
   return;                                                                     // return nothing                   //
 } // of method readInafromEEPROM()                                            //                                  //
@@ -63,7 +64,8 @@ void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {               //
 ** Private method writeInatoEEPROM writes the "ina" structure to EEPROM                                           **
 *******************************************************************************************************************/
 void INA_Class::writeInatoEEPROM(const uint8_t deviceNumber) {                //                                  //
-  EEPROM.put(deviceNumber*sizeof(ina),ina);                                   // Write the structure              //
+  inaEE = ina;                                                                // only save part of ina            //
+  EEPROM.put(deviceNumber*sizeof(inaEE),inaEE);                               // Write the structure              //
   return;                                                                     // return nothing                   //
 } // of method writeInatoEEPROM()                                             //                                  //
 /*******************************************************************************************************************
@@ -85,7 +87,7 @@ uint8_t INA_Class::begin(const uint8_t maxBusAmps,                            //
     #ifndef ESP8266                                                           // I2C begin() on Esplora problems  //
       Wire.begin();                                                           // Start I2C communications         //
     #endif                                                                    //                                  //
-    uint8_t maxDevices = EEPROM.length() / sizeof(ina);                       // Compute number devices possible  //
+    uint8_t maxDevices = EEPROM.length() / sizeof(inaEE);                     // Compute number devices possible  //
     for(uint8_t deviceAddress = 0x40;deviceAddress<0x80;deviceAddress++) {    // Loop for each possible address   //
       Wire.beginTransmission(deviceAddress);                                  // See if something is at address   //
       if (Wire.endTransmission() == 0 && _DeviceCount < maxDevices) {         // If no error and EEPROM has space //

--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -363,27 +363,19 @@ void INA_Class::setShuntConversion(const uint32_t convTime,                   //
 ** Method getDeviceName returns a text representation of the device name according to the device type stored in   **
 ** the EEPROM structure                                                                                           **
 *******************************************************************************************************************/
-char * INA_Class::getDeviceName(const uint8_t deviceNumber) {                 //                                  //
-  static char deviceName[8];                                                  // declare return value             //
+const char* INA_Class::getDeviceName(const uint8_t deviceNumber) {            //                                  //
   readInafromEEPROM(deviceNumber);                                            // Load EEPROM to ina structure     //
   switch ( ina.type ) {                                                       // Set value depending on type      //
-    case INA219  : strcpy(deviceName,"INA219");                               //                                  //
-                   break;                                                     //                                  //
-    case INA226  : strcpy(deviceName,"INA226");                               //                                  //
-                   break;                                                     //                                  //
-    case INA230  : strcpy(deviceName,"INA230");                               //                                  //
-                   break;                                                     //                                  //
-    case INA231  : strcpy(deviceName,"INA231");                               //                                  //
-                   break;                                                     //                                  //
-    case INA260  : strcpy(deviceName,"INA260");                               //                                  //
-                   break;                                                     //                                  //
+    case INA219 : return("INA219");                                           //                                  //
+    case INA226 : return("INA226");                                           //                                  //
+    case INA230 : return("INA230");                                           //                                  //
+    case INA231 : return("INA231");                                           //                                  //
+    case INA260 : return("INA260");                                           //                                  //
     case INA3221_0:                                                           //                                  //
     case INA3221_1:                                                           //                                  //
-    case INA3221_2:strcpy(deviceName,"INA3221");                              //                                  //
-                  break;                                                      //                                  //
-    default      : strcpy(deviceName,"UNKNOWN");                              //                                  //
-  } // of switch on type                                                      //                                  //
-  return(deviceName);                                                         // return device type number        //
+    case INA3221_2:return("INA3221");                                         //                                  //
+    default:      return("UNKNOWN");                                          //                                  //
+  } // of switch type                                                         //                                  //
 } // of method getDeviceName()                                                //                                  //
 /*******************************************************************************************************************
 ** Method getBusMilliVolts retrieves the bus voltage measurement                                                  **

--- a/src/INA.h
+++ b/src/INA.h
@@ -66,6 +66,8 @@
     uint32_t address              : 7; // 0-127//                             // I2C Address of device            //
     uint32_t maxBusAmps           : 5; // 0-31 //                             // Store initialization value       //
     uint32_t microOhmR            :20; // 0-1.048.575 //                      // Store initialization value       //
+  } inaEEPROM; // of structure                                                //                                  //
+  typedef struct : inaEEPROM {                                                // Structure of values per device   //
     uint8_t  shuntVoltageRegister : 4; // 0-15 //                             // Shunt Voltage Register           //
     uint8_t  currentRegister      : 4; // 0-15 //                             // Current Register                 //
     uint16_t shuntVoltage_LSB;                                                // Device dependent LSB factor      //

--- a/src/INA.h
+++ b/src/INA.h
@@ -208,14 +208,9 @@
                                  const uint8_t deviceAddress);                //                                  //
       void     readInafromEEPROM(const uint8_t deviceNumber);                 // Retrieve structure from EEPROM   //
       void     writeInatoEEPROM (const uint8_t deviceNumber);                 // Write structure to EEPROM        //
-      void     initINA219_INA220(const uint8_t  maxBusAmps,                   // Initialize INA219 or INA220      //
-                                 const uint32_t microOhmR,                    //                                  //
-                                 const uint8_t  deviceNumber);                //                                  //
-      void     initINA226_INA231(const uint8_t maxBusAmps,                    // Initialize INA226, INA230        //
-                                 const uint32_t microOhmR,                    // or INA231                        //
-                                 const uint8_t deviceNumber,                  //                                  //
-                                 const uint8_t ina_type=INA226);              // INA226 by default                //
-      void     initINA260       (const uint8_t maxBusAmps);                   //                                  //
+      void     initINA219_INA220(const uint8_t deviceNumber);                 // Initialize INA219 or INA220      //
+      void     initINA226_INA231(const uint8_t deviceNumber);                 // Initialize INA226,INA230,INA231  //
+      void     initINA260       (const uint8_t deviceNumber);                 // Initialize INA260                //
       void     initINA3221      (const uint8_t deviceNumber);                 // Initialize INA3221               //
       uint8_t  _DeviceCount        = 0;                                       // Number of INAs detected          //
       uint8_t  _currentINA         = UINT8_MAX;                               // Stores current INA device number //

--- a/src/INA.h
+++ b/src/INA.h
@@ -67,13 +67,15 @@
     uint32_t maxBusAmps           : 5; // 0-31 //                             // Store initialization value       //
     uint32_t microOhmR            :20; // 0-1.048.575 //                      // Store initialization value       //
   } inaEEPROM; // of structure                                                //                                  //
-  typedef struct : inaEEPROM {                                                // Structure of values per device   //
+  typedef struct inaDet : inaEEPROM {                                         // Structure of values per device   //
     uint8_t  shuntVoltageRegister : 4; // 0-15 //                             // Shunt Voltage Register           //
     uint8_t  currentRegister      : 4; // 0-15 //                             // Current Register                 //
     uint16_t shuntVoltage_LSB;                                                // Device dependent LSB factor      //
     uint16_t busVoltage_LSB;                                                  // Device dependent LSB factor      //
     uint32_t current_LSB;                                                     // Amperage LSB                     //
     uint32_t power_LSB;                                                       // Wattage LSB                      //
+    inaDet(){}                                                                // struct constructor               //
+    inaDet(inaEEPROM){}                                                       // for ina = inaEE; assignment      //
   } inaDet; // of structure                                                   //                                  //
                                                                               //                                  //
   enum ina_Type { INA219,                                                     // List of supported devices        //
@@ -217,6 +219,7 @@
       void     initINA3221      (const uint8_t deviceNumber);                 // Initialize INA3221               //
       uint8_t  _DeviceCount        = 0;                                       // Number of INAs detected          //
       uint8_t  _currentINA         = UINT8_MAX;                               // Stores current INA device number //
+      inaEEPROM inaEE;                                                        // Declare a single global value    //
       inaDet   ina;                                                           // Declare a single global value    //
   }; // of INA_Class definition                                               //                                  //
 #endif                                                                        //----------------------------------//

--- a/src/INA.h
+++ b/src/INA.h
@@ -208,10 +208,7 @@
                                  const uint8_t deviceAddress);                //                                  //
       void     readInafromEEPROM(const uint8_t deviceNumber);                 // Retrieve structure from EEPROM   //
       void     writeInatoEEPROM (const uint8_t deviceNumber);                 // Write structure to EEPROM        //
-      void     initINA219_INA220(const uint8_t deviceNumber);                 // Initialize INA219 or INA220      //
-      void     initINA226_INA231(const uint8_t deviceNumber);                 // Initialize INA226,INA230,INA231  //
-      void     initINA260       (const uint8_t deviceNumber);                 // Initialize INA260                //
-      void     initINA3221      (const uint8_t deviceNumber);                 // Initialize INA3221               //
+      void     initDevice       (const uint8_t deviceNumber);                 // Initialize any Device            //
       uint8_t  _DeviceCount        = 0;                                       // Number of INAs detected          //
       uint8_t  _currentINA         = UINT8_MAX;                               // Stores current INA device number //
       inaEEPROM inaEE;                                                        // Declare a single global value    //

--- a/src/INA.h
+++ b/src/INA.h
@@ -60,18 +60,18 @@
   ** Declare structures and enumerated types used in the class                                                    **
   *****************************************************************************************************************/
   typedef struct {                                                            // Structure of values per device   //
-    uint8_t  address;                                                         // I2C Address of device            //
     uint8_t  type                 : 3; // 0- 7 //                             // see enumerated "ina_Type"        //
     uint8_t  virtualDeviceNumber  : 2; // 0- 3 //                             // Only used with INA3221           //
     uint8_t  operatingMode        : 3; // 0- 7 //                             // Default to continuous mode       //
+    uint32_t address              : 7; // 0-127//                             // I2C Address of device            //
+    uint32_t maxBusAmps           : 5; // 0-31 //                             // Store initialization value       //
+    uint32_t microOhmR            :20; // 0-1.048.575 //                      // Store initialization value       //
     uint8_t  shuntVoltageRegister : 4; // 0-15 //                             // Shunt Voltage Register           //
     uint8_t  currentRegister      : 4; // 0-15 //                             // Current Register                 //
-    uint8_t  maxBusAmps;                                                      // Store initialization value       //
     uint16_t shuntVoltage_LSB;                                                // Device dependent LSB factor      //
     uint16_t busVoltage_LSB;                                                  // Device dependent LSB factor      //
     uint32_t current_LSB;                                                     // Amperage LSB                     //
     uint32_t power_LSB;                                                       // Wattage LSB                      //
-    uint32_t microOhmR;                                                       // Store initialization value       //
   } inaDet; // of structure                                                   //                                  //
                                                                               //                                  //
   enum ina_Type { INA219,                                                     // List of supported devices        //

--- a/src/INA.h
+++ b/src/INA.h
@@ -207,9 +207,10 @@
       void     initINA219_INA220(const uint8_t  maxBusAmps,                   // Initialize INA219 or INA220      //
                                  const uint32_t microOhmR,                    //                                  //
                                  const uint8_t  deviceNumber);                //                                  //
-      void     initINA226       (const uint8_t maxBusAmps,                    // Initialize INA226                //
-                                 const uint32_t microOhmR,                    //                                  //
-                                 const uint8_t deviceNumber);                 //                                  //
+      void     initINA226_INA231(const uint8_t maxBusAmps,                    // Initialize INA226, INA230        //
+                                 const uint32_t microOhmR,                    // or INA231                        //
+                                 const uint8_t deviceNumber,                  //                                  //
+                                 const uint8_t ina_type=INA226);              // INA226 by default                //
       void     initINA260       (const uint8_t maxBusAmps);                   //                                  //
       void     initINA3221      (const uint8_t deviceNumber);                 // Initialize INA3221               //
       uint8_t  _DeviceCount        = 0;                                       // Number of INAs detected          //

--- a/src/INA.h
+++ b/src/INA.h
@@ -183,7 +183,7 @@
       int32_t  getShuntMicroVolts(const uint8_t  deviceNumber=0);             // Retrieve Shunt voltage in uV     //
       int32_t  getBusMicroAmps   (const uint8_t  deviceNumber=0);             // Retrieve micro-amps              //
       int32_t  getBusMicroWatts  (const uint8_t  deviceNumber=0);             // Retrieve micro-watts             //
-      char *   getDeviceName     (const uint8_t  deviceNumber=0);             // Retrieve device name as char[7]  //
+      const char* getDeviceName  (const uint8_t  deviceNumber=0);             // Retrieve device name (const char)//
       void     reset             (const uint8_t  deviceNumber=0);             // Reset the device                 //
       void     waitForConversion (const uint8_t  deviceNumber=UINT8_MAX);     // wait for conversion to complete  //
       bool     AlertOnConversion (const bool alertState,                      // Enable pin change on conversion  //

--- a/src/INA.h
+++ b/src/INA.h
@@ -74,8 +74,8 @@
     uint16_t busVoltage_LSB;                                                  // Device dependent LSB factor      //
     uint32_t current_LSB;                                                     // Amperage LSB                     //
     uint32_t power_LSB;                                                       // Wattage LSB                      //
-    inaDet(){}                                                                // struct constructor               //
-    inaDet(inaEEPROM){}                                                       // for ina = inaEE; assignment      //
+    inaDet();                                                                 // struct constructor               //
+    inaDet(inaEEPROM inaEE);                                                  // for ina = inaEE; assignment      //
   } inaDet; // of structure                                                   //                                  //
                                                                               //                                  //
   enum ina_Type { INA219,                                                     // List of supported devices        //

--- a/src/INA.h
+++ b/src/INA.h
@@ -60,16 +60,16 @@
   ** Declare structures and enumerated types used in the class                                                    **
   *****************************************************************************************************************/
   typedef struct {                                                            // Structure of values per device   //
-    uint8_t  type                 : 3; // 0- 7 //                             // see enumerated "ina_Type"        //
-    uint8_t  virtualDeviceNumber  : 2; // 0- 3 //                             // Only used with INA3221           //
-    uint8_t  operatingMode        : 3; // 0- 7 //                             // Default to continuous mode       //
+    uint8_t  type                 : 4; // 0-15 //                             // see enumerated "ina_Type"        //
+    uint8_t  operatingMode        : 4; // 0-15 //                             // Default to continuous mode       //
     uint32_t address              : 7; // 0-127//                             // I2C Address of device            //
     uint32_t maxBusAmps           : 5; // 0-31 //                             // Store initialization value       //
     uint32_t microOhmR            :20; // 0-1.048.575 //                      // Store initialization value       //
   } inaEEPROM; // of structure                                                //                                  //
   typedef struct inaDet : inaEEPROM {                                         // Structure of values per device   //
-    uint8_t  shuntVoltageRegister : 4; // 0-15 //                             // Shunt Voltage Register           //
-    uint8_t  currentRegister      : 4; // 0-15 //                             // Current Register                 //
+    uint8_t  busVoltageRegister   : 3; // 0- 7 //                             // Bus Voltage Register             //
+    uint8_t  shuntVoltageRegister : 2; // 0- 4 //                             // Shunt Voltage Register           //
+    uint8_t  currentRegister      : 3; // 0- 7 //                             // Current Register                 //
     uint16_t shuntVoltage_LSB;                                                // Device dependent LSB factor      //
     uint16_t busVoltage_LSB;                                                  // Device dependent LSB factor      //
     uint32_t current_LSB;                                                     // Amperage LSB                     //
@@ -83,7 +83,9 @@
                   INA230,                                                     //                                  //
                   INA231,                                                     //                                  //
                   INA260,                                                     //                                  //
-                  INA3221,                                                    //                                  //
+                  INA3221_0,                                                  // INA3221 1st channel              //
+                  INA3221_1,                                                  // INA3221 2nd channel              //
+                  INA3221_2,                                                  // INA3221 3rd channel              //
                   UNKNOWN };                                                  //                                  //
   enum ina_Mode { INA_MODE_SHUTDOWN,                                          // Device powered down              //
                   INA_MODE_TRIGGERED_SHUNT,                                   // Triggered shunt, no bus          //


### PR DESCRIPTION
# Description
Each device requires 248 bits of EEPROM. Therefore the maximum number of devices on a ATmega328 is 4, and 2 on ATmega168.

This patch reduces the EEPROM requirements to 40 bits per device. Then, an ATmega168 can host up to 12 devices and ATmega328 up to 25.

**NOTE** This patch has not yet been tested in hardware. At this stage, this PR is mainly for code review.

### Data structures
Only part of the `inaDet` struct is saved to EEPROM. The `inaEEPROM` struct contains the values to be saved and `inaDet` expands upon it via inheritance.

The `inaDet:inaDet(inaEEPROM)` constructor infers the remaining data from the `type` field. The inference takes place "behind the scene" every time the constructor is triggered by the `ina = inaEE;` assignment.

The following items describe the major points of the implementation,
and its deviation from my original proposal on #11.

### Device initialisation
Most of the `ina` fields are populated by the `inaDet:inaDet(inaEEPROM)` constructor.
Thus, reducing the in initialisation/reset of `INA260` and `INA3221` devices to setting `ina.operatingMode` and saving saving the device to EEPROM. The  initialisation `INA219` and `ÌNA226` (and derivatives) also sets the `INA_CALIBRATION_REGISTER`.

It seemed reasonable to collect the initialisation of all devices into a single procedure, `INA_Class::initDevice`. This simplified the calls from `INA_Class::begin` and `INA_Class::reset`.

Further simplification came from calling `initDevice` for all 3 `INA3221` channels, instead of only calling for the 1st channel. This ensures that `ina.operatingMode` is reset for all channels.

### `INA3221` channels
The `INA3221` 3 channels are now treated as different device types. This has no effect on the EEPROM footprint of the device, but allows up to 15 different `ina_Type` and `ina_Mode` each instead of 7 each.
I like to think that the treating each channel as a different device type makes the code simpler, but it also introduces a number of additional switch/cases and if/conditions.

Maybe this should be moved to a different issue/PR. Or can be dropped altogether.

### Device names
I also changed `INA_Class::getDeviceName` to `cost char*`. It seems like a cleaner implementation.
Maybe is just my dislike of `strcpy`... Like the the previous item, this can be dropped altogether.

Fixes #11 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- None so far

**Test Configuration**:
- Arduino version: Platform Atmel AVR, from PlatformIO
    - atmelavr 1.9.0
    - toolchain-atmelavr 1.40902.0
    - framework-arduinoavr 1.10621.1
- Arduino Hardware: None so far, just complied the code
- SDK: PlatformIO, version 3.5.4

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [x] My changes generate no new warnings
- [ ] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes