### PR TITLE
support STM32F1 emulated EEPROM

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -109,13 +109,13 @@ void INA_Class::writeWord(const uint8_t addr, const uint16_t data,            //
 void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {               //                                  //
   if (deviceNumber!=_currentINA) {                                            // Only read EEPROM if necessary    //
     #ifdef __STM32F1__                                                        // STM32F1 as no builtin EEPROM, it //
-    uint16 e = deviceNumber*sizeof(ina);                                      // uses flash memory do emulate it  //
-    uint16 *ptr = (uint16*) &ina;                                             // "EEPROM" cells are uint16 type   //
-    for(uint8_t n = sizeof(ina); n ;--n) {                                    // Implement EEPROM.get template    //
+    uint16 e = deviceNumber*sizeof(inaEE);                                    // uses flash memory do emulate it  //
+    uint16 *ptr = (uint16*) &inaEE;                                           // "EEPROM" cells are uint16 type   //
+    for(uint8_t n = sizeof(inaEE); n ;--n) {                                  // Implement EEPROM.get template    //
       EEPROM.read(e++, ptr++);                                                // for ina (inaDet type)            //
     } // for                                                                  //                                  //
     #else                                                                     // EEPROM Library V2.0 for Arduino  //
-    EEPROM.get(deviceNumber*sizeof(ina),ina);                                 // Read EEPROM values               //
+    EEPROM.get(deviceNumber*sizeof(inaEE),inaEE);                             // Read EEPROM values               //
     #endif                                                                    //                                  //
     _currentINA = deviceNumber;                                               // Store new current value          //
     ina = inaEE;                                                              // see inaDet constructor           //
@@ -126,15 +126,15 @@ void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {               //
 ** Private method writeInatoEEPROM writes the "ina" structure to EEPROM                                           **
 *******************************************************************************************************************/
 void INA_Class::writeInatoEEPROM(const uint8_t deviceNumber) {                //                                  //
+  inaEE = ina;                                                                // only save part of ina            //
   #ifdef __STM32F1__                                                          // STM32F1 as no builtin EEPROM, it //
-  uint16 e = deviceNumber*sizeof(ina);                                        // uses flash memory do emulate it  //
-  const uint16 *ptr = (const uint16*) &ina;                                   // "EEPROM" cells are uint16 type   //
-  for(uint8_t n = sizeof(ina); n ;--n) {                                      // Implement EEPROM.put template    //
+  uint16 e = deviceNumber*sizeof(inaEE);                                      // uses flash memory do emulate it  //
+  const uint16 *ptr = (const uint16*) &inaEE;                                 // "EEPROM" cells are uint16 type   //
+  for(uint8_t n = sizeof(inaEE); n ;--n) {                                    // Implement EEPROM.put template    //
     EEPROM.update(e++, *ptr++);                                               // for ina (inaDet type)            //
   } // for                                                                    //                                  //
   #else                                                                       // EEPROM Library V2.0 for Arduino  //
- 
-  EEPROM.put(deviceNumber*sizeof(ina),ina);                                   // Write the structure              //
+  EEPROM.put(deviceNumber*sizeof(inaEE),inaEE);                               // Write the structure              //
   #endif                                                                      //                                  //
   return;                                                                     // return nothing                   //
 } // of method writeInatoEEPROM()                                             //                                  //
@@ -158,9 +158,9 @@ uint8_t INA_Class::begin(const uint8_t maxBusAmps,                            //
       Wire.begin();                                                           // Start I2C communications         //
     #endif                                                                    //                                  //
     #ifdef __STM32F1__                                                        // Emulated EEPROM for STM32F1      //
-    uint8_t maxDevices = EEPROM.maxcount() / sizeof(ina);                     // Compute number devices possible  //
+    uint8_t maxDevices = EEPROM.maxcount() / sizeof(inaEE);                   // Compute number devices possible  //
     #else                                                                     // EEPROM Library V2.0 for Arduino  //
-    uint8_t maxDevices = EEPROM.length() / sizeof(ina);                       // Compute number devices possible  //
+    uint8_t maxDevices = EEPROM.length() / sizeof(inaEE);                     // Compute number devices possible  //
     #endif                                                                    //                                  //
     for(uint8_t deviceAddress = 0x40;deviceAddress<0x80;deviceAddress++) {    // Loop for each possible address   //
       Wire.beginTransmission(deviceAddress);                                  // See if something is at address   //


### PR DESCRIPTION
# Description
STM32F01 microcontrollers have no flash, and the EEPROM library uses flash memory to emulate it. The `EEPROMClass` on this old version of the library does not have the `get`, `put` and `length` methods. These methods are only available on the new version of the library.

Fixes #15

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- compiled the DisplayReadings for different microcontrollers using platformio
  - ATmega168 (board `pro8MHzatmega168`)
  - ATmega328 (board `pro8MHzatmega328`)
  - ATmega32u4 (board `micro`)
  - ATmega2560 (board `megaatmega2560`)
  - ESP8266 (board `d1_mini`)
  - ESP32 (board `mhetesp32minikit`)
  - STM32F103 (board `bluepill_f103c8`)

**Test Configuration**:
- Arduino version: Platform Atmel AVR, from PlatformIO
    - atmelavr 1.9.0
    - toolchain-atmelavr 1.40902.0
    - framework-arduinoavr 1.10621.1
- Arduino Hardware: None so far, just complied the code
- SDK: PlatformIO, version 3.5.4

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [x] My changes generate no new warnings
- [x] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
