### PR TITLE
inconsistent unit on setBusConversion

### DIFF
--- a/examples/BackgroundRead/BackgroundRead.ino
+++ b/examples/BackgroundRead/BackgroundRead.ino
@@ -120,8 +120,8 @@ void setup() {                                                                //
   Serial.println(deviceNumber);                                               //                                  //
   Serial.println();                                                           //                                  //
   INA.setAveraging(64,deviceNumber);                                          // Average each reading 64 times    //
-  INA.setBusConversion(82440,deviceNumber);                                   // Maximum conversion time 8.244ms  //
-  INA.setShuntConversion(82440,deviceNumber);                                 // Maximum conversion time 8.244ms  //
+  INA.setBusConversion(8244,deviceNumber);                                    // Maximum conversion time 8.244ms  //
+  INA.setShuntConversion(8244,deviceNumber);                                  // Maximum conversion time 8.244ms  //
   INA.setMode(INA_MODE_CONTINUOUS_BOTH,deviceNumber);                         // Bus/shunt measured continuously  //
   INA.AlertOnConversion(true,deviceNumber);                                   // Make alert pin go low on finish  //
 } // of method setup()                                                        //                                  //

--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -269,10 +269,10 @@ void INA_Class::setBusConversion(const uint32_t convTime,                     //
                       break;                                                  //                                  //
         case INA226 :                                                         // INA226 and                       //
         case INA3221:                                                         // INA3221 are the same as INA260   //
-        case INA260 : if      (convTime>= 82440) convRate = 7;                // setting depending upon range     //
-                      else if (convTime>= 41560) convRate = 6;                //                                  //
-                      else if (convTime>= 21160) convRate = 5;                //                                  //
-                      else if (convTime>= 11000) convRate = 4;                //                                  //
+        case INA260 : if      (convTime>=  8244) convRate = 7;                // setting depending upon range     //
+                      else if (convTime>=  4156) convRate = 6;                //                                  //
+                      else if (convTime>=  2116) convRate = 5;                //                                  //
+                      else if (convTime>=  1100) convRate = 4;                //                                  //
                       else if (convTime>=   588) convRate = 3;                //                                  //
                       else if (convTime>=   332) convRate = 2;                //                                  //
                       else if (convTime>=   204) convRate = 1;                //                                  //
@@ -317,10 +317,10 @@ void INA_Class::setShuntConversion(const uint32_t convTime,                   //
                       break;                                                  //                                  //
         case INA226 :                                                         // INA226 and                       //
         case INA3221:                                                         // INA3221 are the same as INA260   //
-        case INA260 : if      (convTime>= 82440) convRate = 7;                // setting depending upon range     //
-                      else if (convTime>= 41560) convRate = 6;                //                                  //
-                      else if (convTime>= 21160) convRate = 5;                //                                  //
-                      else if (convTime>= 11000) convRate = 4;                //                                  //
+        case INA260 : if      (convTime>=  8244) convRate = 7;                // setting depending upon range     //
+                      else if (convTime>=  4156) convRate = 6;                //                                  //
+                      else if (convTime>=  2116) convRate = 5;                //                                  //
+                      else if (convTime>=  1100) convRate = 4;                //                                  //
                       else if (convTime>=   588) convRate = 3;                //                                  //
                       else if (convTime>=   332) convRate = 2;                //                                  //
                       else if (convTime>=   204) convRate = 1;                //                                  //


### PR DESCRIPTION
# Description
On `setBusConversion` and `setShuntConversion` should the unit for `convTime`  parameter μs.
Therefore, the if/else clauses for the higher 4 ranges of the INA226 correspond to 82.440 μs,
41.560 μs, 21.160 μs and 11.000 μs. which is one order of magnitude higher than the values on Tables 7 and 8 on the [datasheet][].

[datasheet]: http://www.ti.com/product/INA226/datasheet/detailed_description#SBOS5476604

Fixes #18
** PLEASE NOTE ** that this PR is targeted to the master branch. If I should target other branch, just met me know and I'll work it out.

## Type of change
-  Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- Compile own INA based project for the ATmega328p

**Test Configuration**:
* Arduino version: Platform Atmel AVR, from PlatformIO
  * atmelavr 1.9.0
  * toolchain-atmelavr 1.40902.0
  * framework-arduinoavr 1.10621.1
* Arduino Hardware: None so far, just complied the code
* SDK: PlatformIO, version 3.5.4

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [x] My changes generate no new warnings
- [x] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
