### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,8 +11,8 @@ getBusMilliVolts	KEYWORD2
 getShuntMicroVolts	KEYWORD2
 getBusMicroAmps	KEYWORD2
 getBusMicroWatts	KEYWORD2
-getBusRaw KEYWORD2
-getShuntRaw KEYWORD2
+getBusRaw	KEYWORD2
+getShuntRaw	KEYWORD2
 reset	KEYWORD2
 setMode	KEYWORD2
 setAveraging	KEYWORD2


### PR DESCRIPTION
# Description
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
1. Install library, note that the `getBusRaw` and `getShuntRaw` keywords are not highlighted by the Arduino IDE.
2. Make the proposed change to keywords.txt.
3. Restart the Arduino IDE to make it rescan the library.
4. Confirm that the `getBusRaw` and `getShuntRaw` keywords are now highlighted by the Arduino IDE.