### PR TITLE
Include EEPROM library for Teensy

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -8,7 +8,7 @@
 *******************************************************************************************************************/
 #include <INA.h>                ///< Include the header definition
 #include <Wire.h>               ///< I2C Library definition
-#if defined(__AVR__) || defined(ESP32) || defined(ESP8266)
+#if defined(__AVR__) || defined(CORE_TEENSY) || defined(ESP32) || defined(ESP8266)
 #include <EEPROM.h>             ///< Include the EEPROM library for AVR-Boards
 #endif
 inaDet::inaDet(){}              ///< Empty constructor for INA Detail structure


### PR DESCRIPTION
# Description

Check if the library is being compiled for Teensy and if so, include the `EEPROM` library.

Fixes #47

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Install library.
2. Confirm that when Teensy device is selected as Board Type, library fails to compile with error `'EEPROM' was not declared in this scope`.
3. Make change.
4. Run test program, confirming that library compiles and Teensy is able to communicate with INA119.

**Test Configuration**:
* Hardware: Teensy 3.2
* SDK: Arduino IDE
* Arduino version: 1.8.9
* Teensyduino version: 1.46
