### PR TITLE
Search all 16 addresses for INA

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -216,7 +216,7 @@ uint8_t INA_Class::begin(const uint8_t maxBusAmps, const uint32_t microOhmR, con
     {
       maxDevices = 255;
     } // of if-then more than 255 devices possible
-    for(uint8_t deviceAddress = 0x40;deviceAddress<0x4F;deviceAddress++) // Loop for each possible I2C address
+    for(uint8_t deviceAddress = 0x40;deviceAddress<0x50;deviceAddress++) // Loop for each possible I2C address
     {
       Wire.beginTransmission(deviceAddress);
       uint8_t good = Wire.endTransmission();


### PR DESCRIPTION
# Description
The INA220 supports 16 addresses: `0x40` through `0x4F`. This bugfix allows the library to search for all 16 devices instead of just 15.

Fixes #51

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Confirm that INA220 at address `0x4F` is not detected
2. Make code change
3. Confirm that INA220 at address `0x4F` is detected

**Test Configuration**:
* Arduino version: 1.8.12
* Arduino Hardware: ATmega128
* SDK: Arduino IDE
