### PR TITLE
Development v1.0.12

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,27 +3,25 @@
 ##                                                                            ##
 ## Date       Developer  Description                                          ##
 ## ========== ========== =====================================================##
-## 2020-06-30 SV-Zanshin Changed indentation                                  ##
+## 2020-07-03 SV-Zanshin Removed several options not present in Travis-CI     ##
+## 2020-06-28 SV-Zanshin Changed indentation                                  ##
 ##                                                                            ##
 ################################################################################
 ---
 Language: Cpp
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Never
+AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
-AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
+#AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -32,7 +30,6 @@ AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -58,13 +55,12 @@ BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     100
-CommentPragmas:  '^\\.+'
+CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
@@ -77,20 +73,14 @@ IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
-    SortPriority:    0
   - Regex:           '^<.*\.h>'
     Priority:        1
-    SortPriority:    0
   - Regex:           '^<.*'
     Priority:        2
-    SortPriority:    0
   - Regex:           '.*'
     Priority:        3
-    SortPriority:    0
 IncludeIsMainRegex: '([-_](test|unittest))?$'
-IncludeIsMainSourceRegex: ''
 IndentCaseLabels: true
-IndentGotoLabels: true
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
@@ -146,7 +136,6 @@ ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
@@ -154,22 +143,14 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
-#SpacesInConditionalStatement: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
 Standard:        Auto
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
 TabWidth:        8
-UseCRLF:         false
 UseTab:          Never
 ...
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 ##                                                                                                  ##
 ## Date       Developer  Comments                                                                   ##
 ## ========== ========== ========================================================================== ##
+## 2020-07-12 SV-Zanshin Commented out the "cache:" section, as that was causing the build to fail  ##
 ## 2020-07-03 SV-Zanshin Added elements to call "clang-format" to make sure formatting is correct   ##
 ## 2020-05-11 SV-Zanshin Removed Adafruit libraries which now caused Travis to fail                 ##
 ## 2020-05-03 SV-Zanshin Commented out Adafruit libraries which now caused Travis to fail           ##
@@ -20,10 +21,10 @@ branches:
   except:
     - gh-pages
 
-cache:
-  directories:
-    - ~/arduino_ide
-    - ~/.arduino15/packages/
+#cache:
+#  directories:
+#    - ~/arduino_ide
+#    - ~/.arduino15/packages/
    
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,44 @@
 ######################################################################################################
 ## Travis-CI control file                                                                           ##
 ##                                                                                                  ##
-## Date       Developer           Comments                                                          ##
-## ========== =================== ================================================================= ##
-## 2020-05-11 Arnd@SV-Zanshin     Removed Adafruit libraries which now caused Travis to fail        ##
-## 2020-05-03 Arnd@SV-Zanshin     Commented out Adafruit libraries which now caused Travis to fail  ##
-## 2019-01-20 Arnd@SV-Zanshin     Linked to Adafruit script rather than manually defining all tests ##
-## 2019-01-19 Arnd@SV-Zanshin     Initial coding                                                    ##
+## Date       Developer  Comments                                                                   ##
+## ========== ========== ========================================================================== ##
+## 2020-07-03 SV-Zanshin Added elements to call "clang-format" to make sure formatting is correct   ##
+## 2020-05-11 SV-Zanshin Removed Adafruit libraries which now caused Travis to fail                 ##
+## 2020-05-03 SV-Zanshin Commented out Adafruit libraries which now caused Travis to fail           ##
+## 2019-01-20 SV-Zanshin Linked to Adafruit script rather than manually defining all tests          ##
+## 2019-01-19 SV-Zanshin Initial coding                                                             ##
 ##                                                                                                  ##
 ######################################################################################################
 language: c
 sudo: false
 
-# Blacklist
+#########################################################
+# Keep the gh-pages from being included in the CI runs ##
+#########################################################
 branches:
   except:
     - gh-pages
-    
+
+cache:
+  directories:
+    - ~/arduino_ide
+    - ~/.arduino15/packages/
+   
 git:
   depth: false
   quiet: true
+
+addons:
+  apt:
+    sources:
+      - llvm-toolchain-trusty-5.0
+      - key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
+    packages:
+      - python3-pip
+      - python3-wheel
+      - clang-format-5.0
+
 env:
   global:
     - PRETTYNAME="SV-Zanshin INA2xx Arduino Library"
@@ -27,10 +46,13 @@ env:
 
 before_install:
   - source <(curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/install.sh)
+  - curl -SLs https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/run-clang-format.py > run-clang-format.py
+
 
 install:
 
 script:
+  - python run-clang-format.py -r .
   - build_main_platforms
 
 notifications:
@@ -38,5 +60,8 @@ notifications:
     on_success: change
     on_failure: change
 
+###########################################################
+# Generate the Doxygen documentation upon successful run ##
+###########################################################
 after_success:
   - source <(curl -SLs  https://raw.githubusercontent.com/adafruit/travis-ci-arduino/master/doxy_gen_and_deploy.sh)

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,15 +1,16 @@
 ######################################################################################################
 ## Doxygen control file for Version 1.8.16                                                          ##
 ##                                                                                                  ##
-## Date       Developer           Comments                                                          ##
-## ========== =================== ================================================================= ##
-## 2020-06-06 Arnd@SV-Zanshin     Updated to version v1.0.11                                        ##
-## 2020-05-10 Arnd@SV-Zanshin     Removed all comments in order to compact this file                ##
+## Date       Developer      Comments                                                               ##
+## ========== ============== ====================================================================== ##
+## 2020-06-30 SV-Zanshin     Updated to version v1.0.12                                             ##
+## 2020-06-06 SV-Zanshin     Updated to version v1.0.11                                             ##
+## 2020-05-10 SV-Zanshin     Removed all comments in order to compact this file                     ##
 ##                                                                                                  ##
 ######################################################################################################
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = INA2xx
-PROJECT_NUMBER         = "Version 1.0.11"
+PROJECT_NUMBER         = "Version 1.0.12"
 PROJECT_BRIEF          = "Arduino Library for INA2xx power measurement devices"
 PROJECT_LOGO           = images/horizontal_narrow_small.png
 OUTPUT_DIRECTORY       =

--- a/examples/DisplayReadings/DisplayReadings.ino
+++ b/examples/DisplayReadings/DisplayReadings.ino
@@ -98,7 +98,7 @@ void setup() {
 #ifdef __AVR_ATmega32U4__  // If a 32U4 processor, then wait 2 seconds to initialize
   delay(2000);
 #endif
-  Serial.print("\n\nDisplay INA Readings V1.0.6\n");
+  Serial.print("\n\nDisplay INA Readings V1.0.7\n");
   Serial.print(" - Searching & Initializing INA devices\n");
   /************************************************************************************************
   ** The INA.begin call initializes the device(s) found with an expected ±1 Amps maximum current **

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=INA2xx
-version=1.0.11
+version=1.0.12
 author=https://github.com/SV-Zanshin
 maintainer=https://github.com/SV-Zanshin
 sentence=Read current and voltage data from multiple INA2xx devices

--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -115,12 +115,12 @@ void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {
 #ifdef __STM32F1__                               // STM32F1 has no built-in EEPROM
   uint16_t  e   = deviceNumber * sizeof(inaEE);  // it uses flash memory to emulate
   uint16_t *ptr = (uint16_t *)&inaEE;            // "EEPROM" calls are uint16_t type
-  for (uint8_t n = sizeof(inaEE); n; --n)        // Implement EEPROM.get template
+  for (uint8_t n = sizeof(inaEE) + _EEPROM_offset; n; --n)  // Implement EEPROM.get template
   {
     EEPROM.read(e++, ptr++);  // for ina (inaDet type)
   }                           // of for-next each byte
 #else
-  EEPROM.get(deviceNumber * sizeof(inaEE), inaEE);  // Read EEPROM values to structure
+  EEPROM.get(_EEPROM_offset + (deviceNumber * sizeof(inaEE)), inaEE);  // Read EEPROM values
 #endif
 #else
   inaEE                          = _EEPROMEmulation[deviceNumber];
@@ -135,15 +135,15 @@ void INA_Class::writeInatoEEPROM(const uint8_t deviceNumber) {
       @param[in] deviceNumber Index to device array */
   inaEE = ina;  // only save relevant part of ina to EEPROM
 #if defined(__AVR__) || defined(CORE_TEENSY) || defined(ESP32) || defined(ESP8266) || (__STM32F1__)
-#ifdef __STM32F1__                                     // STM32F1 has no built-in EEPROM
-  uint16_t        e   = deviceNumber * sizeof(inaEE);  // it uses flash memory to emulate
-  const uint16_t *ptr = (const uint16_t *)&inaEE;      // "EEPROM" calls are uint16_t type
-  for (uint8_t n = sizeof(inaEE); n; --n)              // Implement EEPROM.put template
+#ifdef __STM32F1__                                         // STM32F1 has no built-in EEPROM
+  uint16_t        e   = deviceNumber * sizeof(inaEE);      // it uses flash memory to emulate
+  const uint16_t *ptr = (const uint16_t *)&inaEE;          // "EEPROM" calls are uint16_t type
+  for (uint8_t n = sizeof(inaEE) + _EEPROM_offset; n; --n) // Implement EEPROM.put template
   {
     EEPROM.update(e++, *ptr++);  // for ina (inaDet type)
   }                              // for-next
 #else
-  EEPROM.put(deviceNumber * sizeof(inaEE), inaEE);  // Write the structure
+  EEPROM.put(_EEPROM_offset+(deviceNumber * sizeof(inaEE)), inaEE);   // Write the structure
 #ifdef ESP32
   EEPROM.commit();                                  // Force write to EEPROM when ESP32
 #endif

--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -604,9 +604,11 @@ int32_t INA_Class::getBusMicroAmps(const uint8_t deviceNumber) {
   if (ina.type == INA3221_0 || ina.type == INA3221_1 ||
       ina.type == INA3221_2)  // Doesn't compute Amps
   {
-    microAmps = getShuntMicroVolts(deviceNumber) * ((int32_t)1000000 / (int32_t)ina.microOhmR);
+    microAmps =
+        (int64_t)getShuntMicroVolts(deviceNumber) * ((int64_t)1000000 / (int64_t)ina.microOhmR);
   } else {
-    microAmps = (int64_t)readWord(ina.currentRegister, ina.address) * ina.current_LSB / 1000;
+    microAmps = (int64_t)readWord(ina.currentRegister, ina.address) * (int64_t)ina.current_LSB /
+                (int64_t)1000;
   }  // of if-then-else an INA3221
   return (microAmps);
 }  // of method getBusMicroAmps()
@@ -623,10 +625,12 @@ int64_t INA_Class::getBusMicroWatts(const uint8_t deviceNumber) {
   if (ina.type == INA3221_0 || ina.type == INA3221_1 ||
       ina.type == INA3221_2)  // Doesn't compute Amps
   {
-    microWatts = (getShuntMicroVolts(deviceNumber) * 1000000 / ina.microOhmR) *
-                 getBusMilliVolts(deviceNumber) / 1000;
+    microWatts =
+        ((int64_t)getShuntMicroVolts(deviceNumber) * (int64_t)1000000 / (int64_t)ina.microOhmR) *
+        (int64_t)getBusMilliVolts(deviceNumber) / (int64_t)1000;
   } else {
-    microWatts = (int64_t)readWord(INA_POWER_REGISTER, ina.address) * ina.power_LSB / 1000;
+    microWatts =
+        (int64_t)readWord(INA_POWER_REGISTER, ina.address) * (int64_t)ina.power_LSB / (int64_t)1000;
   }  // of if-then-else an INA3221
   return (microWatts);
 }  // of method getBusMicroWatts()

--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -112,9 +112,9 @@ void INA_Class::readInafromEEPROM(const uint8_t deviceNumber) {
       @param[in] deviceNumber Index to device array */
   if (deviceNumber == _currentINA || deviceNumber > _DeviceCount) return;  // Skip if correct device
 #if defined(__AVR__) || defined(CORE_TEENSY) || defined(ESP32) || defined(ESP8266) || (__STM32F1__)
-#ifdef __STM32F1__                               // STM32F1 has no built-in EEPROM
-  uint16_t  e   = deviceNumber * sizeof(inaEE);  // it uses flash memory to emulate
-  uint16_t *ptr = (uint16_t *)&inaEE;            // "EEPROM" calls are uint16_t type
+#ifdef __STM32F1__                                          // STM32F1 has no built-in EEPROM
+  uint16_t  e   = deviceNumber * sizeof(inaEE);             // it uses flash memory to emulate
+  uint16_t *ptr = (uint16_t *)&inaEE;                       // "EEPROM" calls are uint16_t type
   for (uint8_t n = sizeof(inaEE) + _EEPROM_offset; n; --n)  // Implement EEPROM.get template
   {
     EEPROM.read(e++, ptr++);  // for ina (inaDet type)
@@ -135,17 +135,17 @@ void INA_Class::writeInatoEEPROM(const uint8_t deviceNumber) {
       @param[in] deviceNumber Index to device array */
   inaEE = ina;  // only save relevant part of ina to EEPROM
 #if defined(__AVR__) || defined(CORE_TEENSY) || defined(ESP32) || defined(ESP8266) || (__STM32F1__)
-#ifdef __STM32F1__                                         // STM32F1 has no built-in EEPROM
-  uint16_t        e   = deviceNumber * sizeof(inaEE);      // it uses flash memory to emulate
-  const uint16_t *ptr = (const uint16_t *)&inaEE;          // "EEPROM" calls are uint16_t type
-  for (uint8_t n = sizeof(inaEE) + _EEPROM_offset; n; --n) // Implement EEPROM.put template
+#ifdef __STM32F1__                                          // STM32F1 has no built-in EEPROM
+  uint16_t        e   = deviceNumber * sizeof(inaEE);       // it uses flash memory to emulate
+  const uint16_t *ptr = (const uint16_t *)&inaEE;           // "EEPROM" calls are uint16_t type
+  for (uint8_t n = sizeof(inaEE) + _EEPROM_offset; n; --n)  // Implement EEPROM.put template
   {
     EEPROM.update(e++, *ptr++);  // for ina (inaDet type)
   }                              // for-next
 #else
-  EEPROM.put(_EEPROM_offset+(deviceNumber * sizeof(inaEE)), inaEE);   // Write the structure
+  EEPROM.put(_EEPROM_offset + (deviceNumber * sizeof(inaEE)), inaEE);  // Write the structure
 #ifdef ESP32
-  EEPROM.commit();                                  // Force write to EEPROM when ESP32
+  EEPROM.commit();                                                     // Force write to EEPROM when ESP32
 #endif
 #endif
 #else
@@ -189,14 +189,14 @@ uint8_t INA_Class::begin(const uint16_t maxBusAmps, const uint32_t microOhmR,
 ** RAM available at runtime to allocate sufficient space for 32 devices.                     **
 **********************************************************************************************/
 #if defined(ESP32) || defined(ESP8266)
-    EEPROM.begin(512);                 // If ESP32 then allocate 512 Bytes
-    maxDevices = 512 / sizeof(inaEE);  // and compute number of devices
-#elif defined(__STM32F1__)             // Emulated EEPROM for STM32F1
-    maxDevices = EEPROM.maxcount() / sizeof(inaEE);  // Compute number devices possible
-#elif defined(CORE_TEENSY)             // TEENSY doesn't have EEPROM.length
-    maxDevices = 2048 / sizeof(inaEE);  // defined, so use 2Kb as value
+    EEPROM.begin(512);                                    // If ESP32 then allocate 512 Bytes
+    maxDevices = (_EEPROM_offset + 512) / sizeof(inaEE);  // and compute number of devices
+#elif defined(__STM32F1__)                                // Emulated EEPROM for STM32F1
+    maxDevices = (_EEPROM_offset + EEPROM.maxcount()) / sizeof(inaEE);  // Compute max possible
+#elif defined(CORE_TEENSY)                                // TEENSY doesn't have EEPROM.length
+    maxDevices = (_EEPROM_offset + 2048) / sizeof(inaEE);  // defined, so use 2Kb as value
 #elif defined(__AVR__)
-    maxDevices = EEPROM.length() / sizeof(inaEE);  // Compute number devices possible
+    maxDevices = (_EEPROM_offset + EEPROM.length()) / sizeof(inaEE);  // Compute max possible
 #else
     maxDevices = 32;
 #endif

--- a/src/INA.h
+++ b/src/INA.h
@@ -77,6 +77,7 @@
  *
  * Version | Date       | Developer   | Comments
  * ------- | ---------- | ----------- | --------
+ * 1.0.12  | 2020-07-03 | SV-Zanshin  | Issue #41. Added "EEPROM_offset" variable
  * 1.0.12  | 2020-07-03 | sages       | Issue #60. Possible Overflow getBus(MicroAmps,MicroWatts)
  * 1.0.11  | 2020-06-30 | SV-Zanshin  | Issue #58, changed formatting to use clang-format
  * 1.0.11  | 2020-06-29 | SV-Zanshin  | Issue #57. "Alert..." functions should be "alert..."
@@ -289,7 +290,7 @@ class INA_Class {
                                      const uint8_t deviceNumber = UINT8_MAX);
   bool        alertOnPowerOverLimit(const bool alertState, const int32_t milliAmps,
                                     const uint8_t deviceNumber = UINT8_MAX);
-
+  uint16_t    _EEPROM_offset = 0; ///< Offset to all EEPROM addresses, GitHub issue #41
  private:
   int16_t   readWord(const uint8_t addr, const uint8_t deviceAddress);
   void      writeWord(const uint8_t addr, const uint16_t data, const uint8_t deviceAddress);

--- a/src/INA.h
+++ b/src/INA.h
@@ -77,7 +77,7 @@
  *
  * Version | Date       | Developer   | Comments
  * ------- | ---------- | ----------- | --------
- * 1.0.12  | 2020-07-03 | SV-Zanshin  | Issue #41. Added "EEPROM_offset" variable
+ * 1.0.12  | 2020-07-03 | SV-Zanshin  | Issue #41. Added "_EEPROM_offset" variable
  * 1.0.12  | 2020-07-03 | sages       | Issue #60. Possible Overflow getBus(MicroAmps,MicroWatts)
  * 1.0.11  | 2020-06-30 | SV-Zanshin  | Issue #58, changed formatting to use clang-format
  * 1.0.11  | 2020-06-29 | SV-Zanshin  | Issue #57. "Alert..." functions should be "alert..."

--- a/src/INA.h
+++ b/src/INA.h
@@ -77,6 +77,7 @@
  *
  * Version | Date       | Developer   | Comments
  * ------- | ---------- | ----------- | --------
+ * 1.0.12  | 2020-07-03 | sages       | Issue #60. Possible Overflow getBus(MicroAmps,MicroWatts)
  * 1.0.11  | 2020-06-30 | SV-Zanshin  | Issue #58, changed formatting to use clang-format
  * 1.0.11  | 2020-06-29 | SV-Zanshin  | Issue #57. "Alert..." functions should be "alert..."
  * 1.0.11  | 2020-05-05 | oliverb68   | Issue #56. Limit of +/- 2kW on getBusMicroWatts

--- a/src/INA.h
+++ b/src/INA.h
@@ -290,7 +290,7 @@ class INA_Class {
                                      const uint8_t deviceNumber = UINT8_MAX);
   bool        alertOnPowerOverLimit(const bool alertState, const int32_t milliAmps,
                                     const uint8_t deviceNumber = UINT8_MAX);
-  uint16_t    _EEPROM_offset = 0; ///< Offset to all EEPROM addresses, GitHub issue #41
+  uint16_t    _EEPROM_offset = 0;  ///< Offset to all EEPROM addresses, GitHub issue #41
  private:
   int16_t   readWord(const uint8_t addr, const uint8_t deviceAddress);
   void      writeWord(const uint8_t addr, const uint16_t data, const uint8_t deviceAddress);


### PR DESCRIPTION
# Description
Reformatted to standard "Google" c++ using clang-format and implemented enhancements and bug-fixes

Fixes # (issue)
Closes #60  @sages - Fixed possible overflows in computations for getBusMicroAmps() and getBusMicroWatts().
Closes #41 @SV-Zanshin - Added public variable "_EEPROM_offset" to allow reserving EEPROM space.
## Type of change

_Please delete options that are not relevant._

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

Tested on ESP32 Feather, AVR-Platforms not impacted

**Test Configuration**:
* Arduino version: 1.8.12
* Arduino Hardware: Micro, ESP32, Uno
* SDK: Visual Studio with Visual Micro
* Development system: Windows

# Checklist:

- [X] The changes made link back to an existing issue number
- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [X] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [X] I have made corresponding changes to the documentation / Wiki Page(s)
- [X] My changes generate no new warnings
- [X] The automated TRAVIS-CI run has a status of "passed"
- [X] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://www.sv-zanshin.com)
