### PR TITLE
add basic INA228 support

### DIFF
--- a/src/INA.cpp
+++ b/src/INA.cpp
@@ -701,7 +701,7 @@ int32_t INA_Class::getBusMicroAmps(const uint8_t deviceNumber) {
       raw = raw >> 4;
     }  // if-then negative
 
-    microAmps = ((int64_t)raw * (int64_t)ina.current_LSB) / 1000ULL;
+    microAmps = ((int64_t)raw * (int64_t)ina.current_LSB) / 1000LL;
     break;
   default:
     microAmps = (int64_t)readWord(ina.currentRegister, ina.address) * (int64_t)ina.current_LSB /

--- a/src/INA.h
+++ b/src/INA.h
@@ -259,13 +259,19 @@ const uint16_t INA226_CONFIG_SADC_MASK{0x0038};     ///< INA226 Bits 3-4
 
 const uint8_t  INA228_DIE_ID_REGISTER{0x3F};        ///< INA228 Device_ID  Register
 const uint16_t INA228_DIE_ID_VALUE{0x2280};         ///< INA228 Hard-coded Die ID for INA228
+const uint8_t  INA228_CALIBRATION_REGISTER{0x2};    ///< INA228 Calibration Register
 const uint8_t  INA228_BUS_VOLTAGE_REGISTER{0x5};    ///< INA228 Bus Voltage Register
-const uint16_t INA228_BUS_VOLTAGE_LSB{195};           ///< INA228 LSB in uV *100 1953125uV, extra code
-const uint8_t  INA228_SHUNT_VOLTAGE_REGISTER{4};    ///< INA228 Shunt Voltage Register
-const uint8_t  xINA228_CURRENT_REGISTER{4};          ///< INA228 Current Register
-const uint16_t xINA228_CONFIG_AVG_MASK{0x0E00};      ///< INA228 Bits 9-11
-const uint16_t xINA228_CONFIG_BADC_MASK{0x01C0};     ///< INA228 Bits 6-8 masked
-const uint16_t xINA228_CONFIG_SADC_MASK{0x0038};     ///< INA228 Bits 3-4
+const uint32_t INA228_BUS_VOLTAGE_LSB{1953125};     ///< INA228 LSB in pV * 100 195.3125uV
+const uint8_t  INA228_SHUNT_VOLTAGE_REGISTER{0x4};  ///< INA228 Shunt Voltage Register
+const uint16_t INA228_SHUNT_VOLTAGE_LSB{3125};      ///< INA228 LSB in nV * 10 312.5nV
+const uint8_t  INA228_CURRENT_REGISTER{0x7};        ///< INA228 Current Register
+const uint8_t  INA228_POWER_REGISTER{0x8};          ///< INA228 Power Register
+const uint8_t  INA228_CONFIGURATION_REGISTER{0x1};  ///< INA228 Configuration Register address
+const uint16_t INA228_CONFIG_MODE_MASK{0xF000};     ///< INA228 Bits 12-15
+const uint16_t INA228_CONFIG_BADC_MASK{0x0E00};     ///< INA228 Bits 9-11
+const uint16_t INA228_CONFIG_SADC_MASK{0x01C0};     ///< INA228 Bits 6-8
+const uint16_t INA228_CONFIG_TADC_MASK{0x0038};     ///< INA228 Bits 3-5
+const uint16_t INA228_CONFIG_AVG_MASK{0x0007};      ///< INA228 Bits 0-2
 
 const uint8_t  INA260_SHUNT_VOLTAGE_REGISTER{0};    ///< INA260 Register doesn't exist
 const uint8_t  INA260_CURRENT_REGISTER{1};          ///< INA260 Current Register


### PR DESCRIPTION
# Description
INA228 support

Fixes #77 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Some tests with two INA228 on custom HW using modified `DisplayReadings.ino` example and custom code with
```
INA.getBusMilliVolts()
INA.getBusMicroAmps()
INA.getBusMicroWatts()
```

**Test Configuration**:
* Arduino version: ???
* Arduino Hardware: AZ-Delivery ESP-32 Dev Kit C V4
* SDK: VSCode + PlatformIO + framework-arduinoespressif32 @ 3.20005.220925 (2.0.5) + Wire @ 2.0.0
* Development system: Ubuntu 20.04

# Checklist:

- [x] The changes made link back to an existing issue number
- [x] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [ ] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [ ] My changes generate no new warnings
- [ ] The automated TRAVIS-CI run has a status of "passed"
- [x] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://zanduino.github.io)
